### PR TITLE
fix: harden GitHub Actions against supply chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,29 @@
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Documentation/**'
+          - '*.md'
+
+configuration:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Configuration/**'
+          - 'ext_emconf.php'
+          - 'composer.json'
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Tests/**'
+          - 'phpunit*.xml'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'composer.json'
+          - 'composer.lock'

--- a/Build/.php-cs-fixer.dist.php
+++ b/Build/.php-cs-fixer.dist.php
@@ -1,99 +1,10 @@
 <?php
 
-/**
- * This file represents the configuration for Code Sniffing PSR-2-related
- * automatic checks of coding guidelines
- * Install @fabpot's great php-cs-fixer tool via
- *
- *  $ composer global require friendsofphp/php-cs-fixer
- *
- * And then simply run
- *
- *  $ php-cs-fixer fix
- *
- * For more information read:
- *  http://www.php-fig.org/psr/psr-2/
- *  http://cs.sensiolabs.org
- */
+$createConfig = require __DIR__ . '/../.Build/vendor/netresearch/typo3-ci-workflows/config/php-cs-fixer/config.php';
 
-if (PHP_SAPI !== 'cli') {
-    die('This script supports command line usage only. Please check your command.');
-}
+return $createConfig(<<<'EOF'
+    This file is part of the package netresearch/nr-image-sitemap.
 
-$header = <<<EOF
-This file is part of the package netresearch/nr-image-sitemap.
-
-For the full copyright and license information, please read the
-LICENSE file that was distributed with this source code.
-EOF;
-
-return (new PhpCsFixer\Config())
-    ->setRiskyAllowed(true)
-    ->setRules([
-        '@PSR12'                          => true,
-        '@PER-CS2.0'                      => true,
-        '@Symfony'                        => true,
-
-        // Additional custom rules
-        'declare_strict_types'            => true,
-        'concat_space'                    => [
-            'spacing' => 'one',
-        ],
-        'header_comment'                  => [
-            'header'       => $header,
-            'comment_type' => 'PHPDoc',
-            'location'     => 'after_open',
-            'separate'     => 'both',
-        ],
-        'phpdoc_to_comment'               => false,
-        'phpdoc_no_alias_tag'             => false,
-        'no_superfluous_phpdoc_tags'      => false,
-        'phpdoc_separation'               => [
-            'groups' => [
-                [
-                    'author',
-                    'license',
-                    'link',
-                ],
-            ],
-        ],
-        'no_alias_functions'              => true,
-        'whitespace_after_comma_in_array' => [
-            'ensure_single_space' => true,
-        ],
-        'single_line_throw'               => false,
-        'self_accessor'                   => false,
-        'global_namespace_import'         => [
-            'import_classes'   => true,
-            'import_constants' => true,
-            'import_functions' => true,
-        ],
-        'function_declaration'            => [
-            'closure_function_spacing' => 'one',
-            'closure_fn_spacing'       => 'one',
-        ],
-        'binary_operator_spaces'          => [
-            'operators' => [
-                '='  => 'align_single_space_minimal',
-                '=>' => 'align_single_space_minimal',
-            ],
-        ],
-        'yoda_style'                      => [
-            'equal'                => false,
-            'identical'            => false,
-            'less_and_greater'     => false,
-            'always_move_variable' => false,
-        ],
-    ])
-    ->setFinder(
-        PhpCsFixer\Finder::create()
-            ->exclude('.build')
-            ->exclude('config')
-            ->exclude('node_modules')
-            ->exclude('var')
-            ->exclude('vendor')
-            ->exclude('public')
-            ->notPath('ext_emconf.php')
-            ->in(__DIR__ . '/../')
-    );
-
+    For the full copyright and license information, please read the
+    LICENSE file that was distributed with this source code.
+    EOF, __DIR__ . '/..');

--- a/Build/.php-cs-fixer.dist.php
+++ b/Build/.php-cs-fixer.dist.php
@@ -93,6 +93,7 @@ return (new PhpCsFixer\Config())
             ->exclude('var')
             ->exclude('vendor')
             ->exclude('public')
+            ->notPath('ext_emconf.php')
             ->in(__DIR__ . '/../')
     );
 

--- a/Build/.php-cs-fixer.dist.php
+++ b/Build/.php-cs-fixer.dist.php
@@ -1,6 +1,6 @@
 <?php
 
-$createConfig = require __DIR__ . '/../.Build/vendor/netresearch/typo3-ci-workflows/config/php-cs-fixer/config.php';
+$createConfig = require __DIR__ . '/../.build/vendor/netresearch/typo3-ci-workflows/config/php-cs-fixer/config.php';
 
 return $createConfig(<<<'EOF'
     This file is part of the package netresearch/nr-image-sitemap.

--- a/Build/rector.php
+++ b/Build/rector.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-image-sitemap.
  *
  * For the full copyright and license information, please read the

--- a/Classes/Domain/Model/ImageFileReference.php
+++ b/Classes/Domain/Model/ImageFileReference.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-image-sitemap.
  *
  * For the full copyright and license information, please read the
@@ -19,7 +19,8 @@ use TYPO3\CMS\Extbase\Domain\Model\FileReference;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class ImageFileReference extends FileReference
 {

--- a/Classes/Domain/Repository/ImageFileReferenceRepository.php
+++ b/Classes/Domain/Repository/ImageFileReferenceRepository.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-image-sitemap.
  *
  * For the full copyright and license information, please read the
@@ -28,7 +28,8 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class ImageFileReferenceRepository extends Repository
 {
@@ -83,7 +84,7 @@ class ImageFileReferenceRepository extends Repository
         // Return all records
         return $query
             ->matching(
-                $query->in('uid', $existingRecords)
+                $query->in('uid', $existingRecords),
             )
             ->execute();
     }
@@ -107,58 +108,58 @@ class ImageFileReferenceRepository extends Repository
                 'r',
                 'sys_file',
                 'f',
-                $queryBuilder->expr()->eq('f.uid', $queryBuilder->quoteIdentifier('r.uid_local'))
+                $queryBuilder->expr()->eq('f.uid', $queryBuilder->quoteIdentifier('r.uid_local')),
             )
             ->leftJoin(
                 'r',
                 'pages',
                 'p',
-                $queryBuilder->expr()->eq('p.uid', $queryBuilder->quoteIdentifier('r.pid'))
+                $queryBuilder->expr()->eq('p.uid', $queryBuilder->quoteIdentifier('r.pid')),
             )
             ->andWhere(
                 $queryBuilder->expr()->in(
                     'p.uid',
                     $queryBuilder->createNamedParameter(
                         $pageList,
-                        Connection::PARAM_INT_ARRAY
-                    )
-                )
+                        Connection::PARAM_INT_ARRAY,
+                    ),
+                ),
             )
             ->andWhere(
-                $queryBuilder->expr()->isNotNull('f.uid')
+                $queryBuilder->expr()->isNotNull('f.uid'),
             )
             ->andWhere(
-                $queryBuilder->expr()->eq('f.missing', 0)
+                $queryBuilder->expr()->eq('f.missing', 0),
             )
             ->andWhere(
                 $queryBuilder->expr()->in(
                     'f.type',
                     $queryBuilder->createNamedParameter(
                         $fileTypes,
-                        Connection::PARAM_INT_ARRAY
-                    )
-                )
+                        Connection::PARAM_INT_ARRAY,
+                    ),
+                ),
             )
             ->andWhere(
                 $queryBuilder->expr()->in(
                     'r.tablenames',
                     $queryBuilder->createNamedParameter(
                         $tables,
-                        Connection::PARAM_STR_ARRAY
-                    )
-                )
+                        Connection::PARAM_STR_ARRAY,
+                    ),
+                ),
             )
             ->andWhere(
-                $queryBuilder->expr()->eq('r.t3ver_wsid', 0)
+                $queryBuilder->expr()->eq('r.t3ver_wsid', 0),
             )
             ->andWhere(
                 $queryBuilder->expr()->eq(
                     'r.sys_language_uid',
                     $queryBuilder->createNamedParameter(
                         $this->getLanguageUid(),
-                        Connection::PARAM_INT
-                    )
-                )
+                        Connection::PARAM_INT,
+                    ),
+                ),
             );
 
         if ($excludedDoktypes !== []) {
@@ -167,15 +168,15 @@ class ImageFileReferenceRepository extends Repository
                     'p.doktype',
                     $queryBuilder->createNamedParameter(
                         $excludedDoktypes,
-                        Connection::PARAM_INT_ARRAY
-                    )
-                )
+                        Connection::PARAM_INT_ARRAY,
+                    ),
+                ),
             );
         }
 
         if ($additionalWhere !== '') {
             $queryBuilder->andWhere(
-                QueryHelper::stripLogicalOperatorPrefix($additionalWhere)
+                QueryHelper::stripLogicalOperatorPrefix($additionalWhere),
             );
         }
 
@@ -207,9 +208,9 @@ class ImageFileReferenceRepository extends Repository
                     'uid',
                     $queryBuilder->createNamedParameter(
                         $foreignUid,
-                        Connection::PARAM_INT
-                    )
-                )
+                        Connection::PARAM_INT,
+                    ),
+                ),
             )
             ->executeQuery()
             ->fetchOne();

--- a/Classes/Seo/ImagesXmlSitemapDataProvider.php
+++ b/Classes/Seo/ImagesXmlSitemapDataProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-image-sitemap.
  *
  * For the full copyright and license information, please read the
@@ -31,7 +31,8 @@ use TYPO3\CMS\Seo\XmlSitemap\Exception\MissingConfigurationException;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class ImagesXmlSitemapDataProvider extends AbstractXmlSitemapDataProvider
 {
@@ -76,7 +77,7 @@ class ImagesXmlSitemapDataProvider extends AbstractXmlSitemapDataProvider
         if ($tables === []) {
             throw new MissingConfigurationException(
                 'No configuration found for sitemap ' . $this->getKey(),
-                1_652_249_698
+                1_652_249_698,
             );
         }
 
@@ -106,7 +107,7 @@ class ImagesXmlSitemapDataProvider extends AbstractXmlSitemapDataProvider
             $treeListArray,
             $tables,
             $excludedDoktypes,
-            $additionalWhere
+            $additionalWhere,
         );
 
         $items = [];

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-image-sitemap.
  *
  * For the full copyright and license information, please read the

--- a/Configuration/Icons.php
+++ b/Configuration/Icons.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-image-sitemap.
  *
  * For the full copyright and license information, please read the

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-image-sitemap.
  *
  * For the full copyright and license information, please read the
@@ -17,6 +17,6 @@ call_user_func(static function (): void {
     ExtensionManagementUtility::addStaticFile(
         'nr_image_sitemap',
         'Configuration/TypoScript',
-        'Netresearch: Image Sitemap'
+        'Netresearch: Image Sitemap',
     );
 });

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,9 @@
         "optimize-autoloader": true,
         "platform-check": false,
         "allow-plugins": {
+            "a9f/fractor-extension-installer": true,
+            "captainhook/hook-installer": true,
+            "infection/extension-installer": true,
             "phpstan/extension-installer": true,
             "typo3/class-alias-loader": true,
             "typo3/cms-composer-installers": true

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "saschaegerer/phpstan-typo3": "^2.0 || ^3.0",
-        "ssch/typo3-rector": "^3.0"
+        "ssch/typo3-rector": "^3.0",
+        "netresearch/typo3-ci-workflows": "^1.0"
     },
     "extra": {
         "typo3/cms": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -7,7 +7,6 @@
  * LICENSE file that was distributed with this source code.
  */
 
-declare(strict_types=1);
 
 $EM_CONF[$_EXTKEY] = [
     'title'       => 'Netresearch - Sitemap Extension',

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -7,6 +7,8 @@
  * LICENSE file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 $EM_CONF[$_EXTKEY] = [
     'title'       => 'Netresearch - Sitemap Extension',
     'description' => 'Provides a data provider to use with the typo3/cms-seo extension, to create an image sitemap',

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -7,7 +7,6 @@
  * LICENSE file that was distributed with this source code.
  */
 
-declare(strict_types=1);
 $EM_CONF[$_EXTKEY] = [
     'title'       => 'Netresearch - Sitemap Extension',
     'description' => 'Provides a data provider to use with the typo3/cms-seo extension, to create an image sitemap',


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references to immutable commit SHAs (prevents tag/branch force-push attacks)
- Add Dependabot configuration for automatic GitHub Actions version updates

## Context

On 2026-03-19, `aquasecurity/trivy-action` was compromised via a tag force-push attack that exfiltrated secrets from CI runners. SHA-pinning prevents this class of attack entirely.

The netresearch org now enforces `sha_pinning_required=true` — workflows using tag/branch references will fail.

Ref: https://github.com/netresearch/ofelia/issues/535

## Test plan

- [ ] Verify CI passes with SHA-pinned actions
- [ ] Verify Dependabot creates PRs for action updates