### PR TITLE
fix: resolve ergebnis/phpstan-rules v2 strict-design violations

### DIFF
--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -26,4 +26,20 @@ parameters:
                 - TYPO3\CMS\Seo\XmlSitemap\AbstractXmlSitemapDataProvider
 
     ignoreErrors:
+        # The XmlSitemapDataProviderInterface::__construct contract from
+        # typo3/cms-seo dictates the exact constructor signature (including
+        # ?ContentObjectRenderer $cObj = null and array $config = []). PHP
+        # enforces strict signature compatibility with interface methods, so
+        # we cannot drop these defaults or the nullable type without producing
+        # a fatal error at runtime. The matching ergebnis violations are
+        # structurally unavoidable for this single class.
+        -
+            identifier: ergebnis.noConstructorParameterWithDefaultValue
+            path: ../Classes/Seo/ImagesXmlSitemapDataProvider.php
+        -
+            identifier: ergebnis.noParameterWithNullableTypeDeclaration
+            path: ../Classes/Seo/ImagesXmlSitemapDataProvider.php
+        -
+            identifier: ergebnis.noParameterWithNullDefaultValue
+            path: ../Classes/Seo/ImagesXmlSitemapDataProvider.php
 

--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -14,5 +14,16 @@ parameters:
 
     treatPhpDocTypesAsCertain: false
 
+    # Allow extending TYPO3 framework base classes that are mandatory integration points:
+    # - FileReference: required to register a custom Extbase file reference domain model
+    # - Repository: required Extbase persistence base class
+    # - AbstractXmlSitemapDataProvider: required base class for typo3/cms-seo data providers
+    ergebnis:
+        noExtends:
+            classesAllowedToBeExtended:
+                - TYPO3\CMS\Extbase\Domain\Model\FileReference
+                - TYPO3\CMS\Extbase\Persistence\Repository
+                - TYPO3\CMS\Seo\XmlSitemap\AbstractXmlSitemapDataProvider
+
     ignoreErrors:
 

--- a/Classes/Domain/Model/ImageFileReference.php
+++ b/Classes/Domain/Model/ImageFileReference.php
@@ -30,30 +30,30 @@ final class ImageFileReference extends FileReference
 
     protected string $tablenames = '';
 
-    public function getTitle(): ?string
+    public function getTitle(): string
     {
         if ($this->title !== '' && $this->title !== '0') {
             return $this->title;
         }
 
         if ($this->getOriginalResource()->hasProperty('title')) {
-            return $this->getOriginalResource()->getProperty('title');
+            return (string) $this->getOriginalResource()->getProperty('title');
         }
 
-        return null;
+        return '';
     }
 
-    public function getDescription(): ?string
+    public function getDescription(): string
     {
         if ($this->description !== '' && $this->description !== '0') {
             return $this->description;
         }
 
         if ($this->getOriginalResource()->hasProperty('description')) {
-            return $this->getOriginalResource()->getProperty('description');
+            return (string) $this->getOriginalResource()->getProperty('description');
         }
 
-        return null;
+        return '';
     }
 
     public function getPublicUrl(): string

--- a/Classes/Domain/Model/ImageFileReference.php
+++ b/Classes/Domain/Model/ImageFileReference.php
@@ -22,7 +22,7 @@ use TYPO3\CMS\Extbase\Domain\Model\FileReference;
  *
  * @see    https://www.netresearch.de
  */
-class ImageFileReference extends FileReference
+final class ImageFileReference extends FileReference
 {
     protected string $title = '';
 

--- a/Classes/Domain/Repository/ImageFileReferenceRepository.php
+++ b/Classes/Domain/Repository/ImageFileReferenceRepository.php
@@ -31,7 +31,7 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  *
  * @see    https://www.netresearch.de
  */
-class ImageFileReferenceRepository extends Repository
+final class ImageFileReferenceRepository extends Repository
 {
     public function __construct(
         protected PersistenceManagerInterface $persistenceManager,

--- a/Classes/Domain/Repository/ImageFileReferenceRepository.php
+++ b/Classes/Domain/Repository/ImageFileReferenceRepository.php
@@ -91,12 +91,13 @@ final class ImageFileReferenceRepository extends Repository
         $query = $this->createQuery();
 
         /** @var array<int, ImageFileReference> $images */
-        $images = $query
-            ->matching(
-                $query->in('uid', $existingRecords),
-            )
-            ->execute()
-            ->toArray();
+        $images = iterator_to_array(
+            $query
+                ->matching(
+                    $query->in('uid', $existingRecords),
+                )
+                ->execute(),
+        );
 
         return $images;
     }

--- a/Classes/Domain/Repository/ImageFileReferenceRepository.php
+++ b/Classes/Domain/Repository/ImageFileReferenceRepository.php
@@ -13,14 +13,15 @@ namespace Netresearch\NrImageSitemap\Domain\Repository;
 
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Result;
+use Netresearch\NrImageSitemap\Domain\Model\ImageFileReference;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryHelper;
+use TYPO3\CMS\Core\Resource\FileType;
 use TYPO3\CMS\Extbase\Persistence\Exception\InvalidQueryException;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
-use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
@@ -44,6 +45,13 @@ final class ImageFileReferenceRepository extends Repository
     /**
      * Returns file references for given file types.
      *
+     * @param array<int, FileType|int> $fileTypes
+     * @param array<int, int>          $pageList
+     * @param array<int, string>       $tables
+     * @param array<int, int>          $excludedDoktypes
+     *
+     * @return array<int, ImageFileReference>
+     *
      * @throws InvalidQueryException
      * @throws Exception
      */
@@ -51,20 +59,24 @@ final class ImageFileReferenceRepository extends Repository
         array $fileTypes,
         array $pageList,
         array $tables,
-        array $excludedDoktypes = [],
-        string $additionalWhere = '',
-    ): ?QueryResultInterface {
+        array $excludedDoktypes,
+        string $additionalWhere,
+    ): array {
         $statement       = $this->getAllRecords($fileTypes, $pageList, $tables, $excludedDoktypes, $additionalWhere);
         $existingRecords = [];
 
         // Walk result set row by row, to prevent too much memory usage
         while ($row = $statement->fetchAssociative()) {
-            if (!isset($row['tablenames'], $row['uid_foreign'])) {
+            if (!array_key_exists('tablenames', $row)) {
+                continue;
+            }
+
+            if (!array_key_exists('uid_foreign', $row)) {
                 continue;
             }
 
             // Check if the foreign table record exists
-            if ($this->findRecordByForeignUid($row['tablenames'], $row['uid_foreign'])) {
+            if ($this->findRecordByForeignUid((string) $row['tablenames'], (int) $row['uid_foreign'])) {
                 $existingRecords[] = (int) $row['uid'];
             }
         }
@@ -73,20 +85,20 @@ final class ImageFileReferenceRepository extends Repository
         $existingRecords = array_unique($existingRecords);
 
         if ($existingRecords === []) {
-            return null;
+            return [];
         }
 
-        $query      = $this->createQuery();
-        $connection = $this->connectionPool->getConnectionForTable('sys_file_reference');
+        $query = $this->createQuery();
 
-        $connection->createQueryBuilder();
-
-        // Return all records
-        return $query
+        /** @var array<int, ImageFileReference> $images */
+        $images = $query
             ->matching(
                 $query->in('uid', $existingRecords),
             )
-            ->execute();
+            ->execute()
+            ->toArray();
+
+        return $images;
     }
 
     /**

--- a/Classes/Domain/Repository/ImageFileReferenceRepository.php
+++ b/Classes/Domain/Repository/ImageFileReferenceRepository.php
@@ -49,6 +49,14 @@ final class ImageFileReferenceRepository extends Repository
      * @param array<int, int>          $pageList
      * @param array<int, string>       $tables
      * @param array<int, int>          $excludedDoktypes
+     * @param string                   $additionalWhere  Raw SQL fragment appended to the `sys_file_reference` query
+     *                                                   via `andWhere()`; any leading boolean operator
+     *                                                   (`AND` / `OR`) is stripped by
+     *                                                   {@see QueryHelper::stripLogicalOperatorPrefix()}. Reference table
+     *                                                   aliases as defined in {@see self::getAllRecords()}: `r` for
+     *                                                   `sys_file_reference`, `f` for `sys_file`, `p` for `pages`
+     *                                                   (e.g. `"r.tablenames = 'pages'"`). Pass an empty string to skip.
+     *                                                   Caller is responsible for quoting / parameterising any values.
      *
      * @return array<int, ImageFileReference>
      *

--- a/Classes/Seo/ImagesXmlSitemapDataProvider.php
+++ b/Classes/Seo/ImagesXmlSitemapDataProvider.php
@@ -43,7 +43,7 @@ final class ImagesXmlSitemapDataProvider extends AbstractXmlSitemapDataProvider
     private readonly LinkFactory $linkFactory;
 
     /**
-     * Constructor signature is fixed by the {@see XmlSitemapDataProviderInterface}
+     * Constructor signature is fixed by the {@see \TYPO3\CMS\Seo\XmlSitemap\XmlSitemapDataProviderInterface}
      * contract, which is part of typo3/cms-seo and cannot be altered here.
      * The four ergebnis rule violations for $config / $cObj are suppressed in
      * Build/phpstan.neon for this file.

--- a/Classes/Seo/ImagesXmlSitemapDataProvider.php
+++ b/Classes/Seo/ImagesXmlSitemapDataProvider.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Netresearch\NrImageSitemap\Seo;
 
 use Doctrine\DBAL\Driver\Exception;
-use Netresearch\NrImageSitemap\Domain\Model\ImageFileReference;
 use Netresearch\NrImageSitemap\Domain\Repository\ImageFileReferenceRepository;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Domain\Repository\PageRepository;
@@ -20,7 +19,6 @@ use TYPO3\CMS\Core\Resource\FileType;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Exception\InvalidQueryException;
-use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Typolink\LinkFactory;
 use TYPO3\CMS\Seo\XmlSitemap\AbstractXmlSitemapDataProvider;
@@ -45,6 +43,13 @@ final class ImagesXmlSitemapDataProvider extends AbstractXmlSitemapDataProvider
     private readonly LinkFactory $linkFactory;
 
     /**
+     * Constructor signature is fixed by the {@see XmlSitemapDataProviderInterface}
+     * contract, which is part of typo3/cms-seo and cannot be altered here.
+     * The four ergebnis rule violations for $config / $cObj are suppressed in
+     * Build/phpstan.neon for this file.
+     *
+     * @param array<string, mixed> $config
+     *
      * @throws InvalidQueryException
      * @throws MissingConfigurationException
      * @throws Exception
@@ -72,7 +77,7 @@ final class ImagesXmlSitemapDataProvider extends AbstractXmlSitemapDataProvider
      */
     public function generateItems(): void
     {
-        $tables = GeneralUtility::trimExplode(',', $this->config['tables']);
+        $tables = GeneralUtility::trimExplode(',', (string) ($this->config['tables'] ?? ''));
 
         if ($tables === []) {
             throw new MissingConfigurationException(
@@ -81,25 +86,20 @@ final class ImagesXmlSitemapDataProvider extends AbstractXmlSitemapDataProvider
             );
         }
 
-        $excludedDoktypes = [];
-        if (isset($this->config['excludedDoktypes']) && $this->config['excludedDoktypes'] !== '') {
-            $excludedDoktypes = GeneralUtility::intExplode(',', $this->config['excludedDoktypes']);
-        }
+        $excludedDoktypesConfig = (string) ($this->config['excludedDoktypes'] ?? '');
+        $excludedDoktypes       = $excludedDoktypesConfig !== ''
+            ? GeneralUtility::intExplode(',', $excludedDoktypesConfig)
+            : [];
 
-        $additionalWhere = '';
-        if (isset($this->config['additionalWhere']) && $this->config['additionalWhere'] !== '') {
-            $additionalWhere = $this->config['additionalWhere'];
-        }
+        $additionalWhere = (string) ($this->config['additionalWhere'] ?? '');
 
-        if (isset($this->config['rootPage']) && $this->config['rootPage'] !== '') {
-            $rootPageId = (int) $this->config['rootPage'];
-        } else {
-            $rootPageId = $this->request->getAttribute('site')->getRootPageId();
-        }
+        $rootPageConfig = (string) ($this->config['rootPage'] ?? '');
+        $rootPageId     = $rootPageConfig !== ''
+            ? (int) $rootPageConfig
+            : $this->request->getAttribute('site')->getRootPageId();
 
         $treeListArray = $this->pageRepository->getPageIdsRecursive([$rootPageId], 99);
 
-        /** @var QueryResultInterface<ImageFileReference>|null $images */
         $images = $this->imageFileReferenceRepository->findAllImages(
             [
                 FileType::IMAGE,
@@ -110,11 +110,11 @@ final class ImagesXmlSitemapDataProvider extends AbstractXmlSitemapDataProvider
             $additionalWhere,
         );
 
-        $items = [];
-
-        if ($images === null || $images->count() === 0) {
+        if ($images === []) {
             return;
         }
+
+        $items = [];
 
         foreach ($images as $image) {
             $link    = $this->linkFactory->createUri((string) $image->getPid());

--- a/Classes/Seo/ImagesXmlSitemapDataProvider.php
+++ b/Classes/Seo/ImagesXmlSitemapDataProvider.php
@@ -34,7 +34,7 @@ use TYPO3\CMS\Seo\XmlSitemap\Exception\MissingConfigurationException;
  *
  * @see    https://www.netresearch.de
  */
-class ImagesXmlSitemapDataProvider extends AbstractXmlSitemapDataProvider
+final class ImagesXmlSitemapDataProvider extends AbstractXmlSitemapDataProvider
 {
     private readonly ImageFileReferenceRepository $imageFileReferenceRepository;
 


### PR DESCRIPTION
## Summary

Scheduled `main` CI run [25656135700](https://github.com/netresearch/t3x-nr-image-sitemap/actions/runs/25656135700) failed PHPStan on all four PHP cells (8.2 / 8.3 / 8.4 / 8.5 × TYPO3 ^13.0). Every violation came from `ergebnis/phpstan-rules` v2.13.1 (transitively pulled in by `saschaegerer/phpstan-typo3` v3.0.0). The CI ruleset is unchanged; the rules are new in the upstream release.

This PR fixes the code rather than baselining the errors.

## Fix categories

| Rule | Strategy | Where |
|------|----------|-------|
| `ergebnis.noExtends` (3 hits) | Add the framework base classes to the rule's documented `classesAllowedToBeExtended` allowlist — not a baseline. The three parents (`Extbase\Domain\Model\FileReference`, `Extbase\Persistence\Repository`, `Seo\XmlSitemap\AbstractXmlSitemapDataProvider`) are mandatory integration points dictated by TYPO3. | `Build/phpstan.neon` |
| `ergebnis.final` (3 hits) | Mark `ImageFileReference`, `ImageFileReferenceRepository`, `ImagesXmlSitemapDataProvider` `final`. None are designed for consumer subclassing. | `Classes/...` |
| `ergebnis.noNullableReturnTypeDeclaration` (3 hits) | `getTitle()` / `getDescription()` now return `string` (empty string is falsy in the consuming Fluid template, so XML output is byte-identical for sitemaps that previously held a `null`). `findAllImages()` returns `array<int, ImageFileReference>` instead of `?QueryResultInterface`. | `ImageFileReference`, `ImageFileReferenceRepository` |
| `ergebnis.noIsset` (4 hits) | Replace `isset()` with `array_key_exists()` (loop guard, splitting the merged `\|\|` into two `continue`s per `ChangeOrIfContinueToMultiContinueRector`) or with null-coalescing `?? ''` (the three `$this->config[...]` reads). | `ImageFileReferenceRepository`, `ImagesXmlSitemapDataProvider` |
| `ergebnis.noConstructorParameterWithDefaultValue` + `ergebnis.noParameterWithNullableTypeDeclaration` + `ergebnis.noParameterWithNullDefaultValue` (4 hits) | **Cannot fix in code.** `TYPO3\CMS\Seo\XmlSitemap\XmlSitemapDataProviderInterface::__construct(...)` declares the signature with `array $config = []` and `?ContentObjectRenderer $cObj = null`. PHP enforces strict signature compatibility with interface methods — dropping the defaults or the nullable produces a runtime fatal (verified locally). Narrowly path-scoped suppression for these three identifiers against this one file only. | `Build/phpstan.neon` |

## Review follow-up

Reviewer flagged reliance on `QueryResult::toArray()` (a concrete Extbase implementation detail, not part of `QueryResultInterface`). Replaced with an explicit iterator-to-array conversion in `ImageFileReferenceRepository::findAllImages()`, which is interface-safe and keeps the public return type as `array<int, ImageFileReference>`.

## Commits

- `b576941` chore(phpstan): allow extending TYPO3 framework base classes
- `b176fc2` refactor: mark domain classes final
- `8554649` refactor: drop nullable returns, replace isset(), tighten signatures
- `df35351` chore(phpstan): scope-ignore three constructor rules forced by typo3/cms-seo interface
- `9e9ff25` refactor: avoid QueryResult::toArray() impl detail, iterate explicitly

## Local verification

All four `composer ci:test:php:*` scripts pass locally on PHP 8.5 with the same composer constraints CI installs:

- `ci:test:php:phpstan` — OK, no errors (down from 18)
- `ci:test:php:lint` — OK, 8 files
- `ci:test:php:cgl` — clean
- `ci:test:php:rector` — clean

## Notes

- No `version:` bump and no CHANGELOG entry (release-flow concern, not a feature change).
- Public surface change: `ImageFileReferenceRepository::findAllImages()` now returns `array` instead of `?QueryResultInterface`. The only in-repo caller (`ImagesXmlSitemapDataProvider::generateItems`) is updated. Downstream consumers (none expected — the repository is an implementation detail of the data provider) would need to swap `$result === null \|\| $result->count() === 0` for `$result === []`.
- Public surface change: `getTitle()` / `getDescription()` widened from `?string` to `string` (return type) — Liskov-compatible widening on return is allowed, and the empty string preserves the template's truthiness check.

## Test plan

- [ ] CI green on `fix/phpstan-strict-design` for all PHP × TYPO3 cells
- [ ] Manual smoke check: install on a TYPO3 v13 instance, request `?type=1533906435&sitemap=images` (or whichever sitemap key is configured), confirm `<image:image>` entries render and the `<image:title>` / `<image:caption>` elements are emitted exactly when the underlying file metadata is set
