### PR TITLE
ci: fire the release workflow on unprefixed tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,12 @@ name: Release
 on:
   push:
     tags:
+      # This repository tags releases WITHOUT a "v" prefix (12.0.2, 13.0.6,
+      # 14.0.0). A "v*" pattern alone therefore never fires, which is why the
+      # 14.0.0 release produced no GitHub release and no TER publish. Match both
+      # spellings; the called workflow strips an optional leading "v".
       - 'v*'
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 permissions: {}
 


### PR DESCRIPTION
The repository tags releases **without** a `v` prefix (`12.0.2`, `13.0.6`, `14.0.0`), but `release.yml` only listened for `v*` — so the trigger never fired.

Observed with the just-pushed `14.0.0` tag: no release workflow run, no GitHub release, no TER publish. Packagist has 14.0.0 regardless, because it ingests tags through its own webhook.

Matches both spellings now (the called workflow strips an optional leading `v`), mirroring the same fix already made in `netresearch/t3x-scheduler`.