### PR TITLE
fix(rector): adopt the shared org rector config

### DIFF
--- a/Build/rector.php
+++ b/Build/rector.php
@@ -10,36 +10,41 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Set\ValueObject\LevelSetList;
-use Rector\Set\ValueObject\SetList;
-use Rector\ValueObject\PhpVersion;
-use Ssch\TYPO3Rector\Configuration\Typo3Option;
+use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
 use Ssch\TYPO3Rector\Set\Typo3LevelSetList;
 use Ssch\TYPO3Rector\Set\Typo3SetList;
 
-return RectorConfig::configure()
-    ->withPaths([
-        __DIR__ . '/../Classes',
-        __DIR__ . '/../Configuration',
-        __DIR__ . '/../Resources',
-        __DIR__ . '/../Tests',
-    ])
-    ->withPhpVersion(PhpVersion::PHP_82)
-    ->withSets([
-        SetList::CODE_QUALITY,
-        SetList::CODING_STYLE,
-        SetList::DEAD_CODE,
-        SetList::EARLY_RETURN,
-        SetList::TYPE_DECLARATION,
+$configure = require_once __DIR__ . '/../.build/vendor/netresearch/typo3-ci-workflows/config/rector/rector.php';
 
-        LevelSetList::UP_TO_PHP_82,
+return static function (RectorConfig $rectorConfig) use ($configure): void {
+    // Shared org base config: code-quality sets, rule skips, phpstan-rector.neon
+    $configure($rectorConfig, __DIR__ . '/..');
 
+    // paths() replaces the shared list — re-declared to keep Tests/ in scope,
+    // which the shared $projectRoot default leaves out.
+    $rectorConfig->paths(array_merge(
+        [
+            __DIR__ . '/../Classes',
+            __DIR__ . '/../Configuration',
+            __DIR__ . '/../Resources',
+            __DIR__ . '/../Tests',
+        ],
+        glob(__DIR__ . '/../ext_*.php') ?: [],
+    ));
+
+    $rectorConfig->sets([
         Typo3SetList::CODE_QUALITY,
         Typo3SetList::GENERAL,
         Typo3LevelSetList::UP_TO_TYPO3_14,
-    ])
-    ->withPHPStanConfigs([
-        Typo3Option::PHPSTAN_FOR_RECTOR_PATH,
-    ])
-    ->withImportNames(true, true, false, true)
-;
+    ]);
+
+    $rectorConfig->skip([
+        // ImageFileReference is final, but its mapped properties MUST stay
+        // `protected`: the Extbase DataMapper assigns them through
+        // AbstractDomainObject::_setProperty(), which does `$this->{$name} = $value`
+        // from the PARENT class scope. A property declared `private` in the child is
+        // inaccessible there, so hydration dies with
+        // "Error: Cannot access private property ImageFileReference::$title".
+        PrivatizeFinalClassPropertyRector::class,
+    ]);
+};

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "phpstan/phpstan-strict-rules": "^2.0",
         "saschaegerer/phpstan-typo3": "^2.0 || ^3.0",
         "ssch/typo3-rector": "^3.0",
-        "netresearch/typo3-ci-workflows": "^1.0"
+        "netresearch/typo3-ci-workflows": "^1.3"
     },
     "extra": {
         "typo3/cms": {


### PR DESCRIPTION
`Build/rector.php` carried its own copy of the base rule sets, rule skips, `importNames` and `phpVersion` settings. Rector 2.6.0 removed `SetList::STRICT_BOOLEANS` and broke every extension that pinned its own baseline, which is why the org policy is now that [netresearch/typo3-ci-workflows](https://github.com/netresearch/typo3-ci-workflows) defines the rule baseline and each extension declares only what is genuinely specific to it. Same conversion as [t3x-nr-image-optimize#150](https://github.com/netresearch/t3x-nr-image-optimize/pull/150), against [typo3-ci-workflows v1.3.4](https://github.com/netresearch/typo3-ci-workflows/releases/tag/v1.3.4).

Kept as repo specifics: `Tests/` in the scanned paths (`paths()` replaces rather than merges, and the shared `$projectRoot` default leaves `Tests/` out, so the list is re-declared with the shared entries plus `Tests/`), and the TYPO3 sets `Typo3SetList::CODE_QUALITY`, `Typo3SetList::GENERAL`, `Typo3LevelSetList::UP_TO_TYPO3_14`.

One new skip was needed. The shared config adds `SetList::PRIVATIZATION`, which this extension did not have before, and `PrivatizeFinalClassPropertyRector` rewrites the three mapped properties of the final `ImageFileReference` from `protected` to `private`. That is not a cosmetic change: the Extbase DataMapper hydrates those properties through `AbstractDomainObject::_setProperty()`, which does `$this->{$propertyName} = $value` from the **parent** class scope, so a `private` property declared in the child is inaccessible there and hydration aborts with `Error: Cannot access private property ImageFileReference::$title`. Confirmed by reading the installed `typo3/cms-extbase` source and by a standalone PHP 8.5 reproduction of the parent-scope assignment, so the rule is skipped with that rationale in a comment and the source file stays untouched. This is the same class of finding as the Extbase-model skip in [t3x-nr-textdb#109](https://github.com/netresearch/t3x-nr-textdb/pull/109).

Dropped as shared-provided: the `SetList` base sets, `LevelSetList::UP_TO_PHP_82`, the standard rule skips, `importNames`/`removeUnusedImports`, the PHPStan config and `phpVersion`. The shared config points Rector at its own `phpstan-rector.neon`, which replaces `Typo3Option::PHPSTAN_FOR_RECTOR_PATH`.

The `require-dev` constraint moves from `^1.0` to `^1.3`, because the `$projectRoot` parameter and the bundled `phpstan-rector.neon` do not exist in 1.0.

Verified with a CI-matched toolchain: `platform.php 8.2.33`, a cold install from an empty vendor directory (no blocked plugins, no `allow-plugins` additions needed), `netresearch/typo3-ci-workflows` resolving to v1.3.4 and Rector 2.6.1. `rector process --dry-run` exits 0 and `composer ci:cgl` fixes nothing. The platform pin was removed again before committing, and `composer.lock` is gitignored. No version bump and no CHANGELOG entry, per the release policy.
