### PR TITLE
chore(deps): drop dev-dependencies the shared package already provides

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -111,7 +111,7 @@ jobs:
     permissions: {}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/composer.json
+++ b/composer.json
@@ -24,14 +24,6 @@
         "typo3/cms-seo": "^13.4 || ^14.3"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.65",
-        "overtrue/phplint": "^9.0",
-        "phpstan/extension-installer": "^1.4",
-        "phpstan/phpstan": "^2.0",
-        "phpstan/phpstan-deprecation-rules": "^2.0",
-        "phpstan/phpstan-strict-rules": "^2.0",
-        "saschaegerer/phpstan-typo3": "^2.0 || ^3.0",
-        "ssch/typo3-rector": "^3.0",
         "netresearch/typo3-ci-workflows": "^1.3"
     },
     "extra": {
@@ -65,6 +57,7 @@
         "optimize-autoloader": true,
         "platform-check": false,
         "allow-plugins": {
+            "ergebnis/composer-normalize": true,
             "a9f/fractor-extension-installer": true,
             "captainhook/hook-installer": true,
             "infection/extension-installer": true,

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "typo3/cms-seo": "^13.4 || ^14.3"
     },
     "require-dev": {
-        "netresearch/typo3-ci-workflows": "^1.3"
+        "netresearch/typo3-ci-workflows": "^1.4"
     },
     "extra": {
         "typo3/cms": {
@@ -57,9 +57,9 @@
         "optimize-autoloader": true,
         "platform-check": false,
         "allow-plugins": {
-            "ergebnis/composer-normalize": true,
             "a9f/fractor-extension-installer": true,
             "captainhook/hook-installer": true,
+            "ergebnis/composer-normalize": true,
             "infection/extension-installer": true,
             "phpstan/extension-installer": true,
             "typo3/class-alias-loader": true,


### PR DESCRIPTION
Part of the fleet-wide dedup pass. Companion to [netresearch/typo3-ci-workflows#158](https://github.com/netresearch/typo3-ci-workflows/pull/158), released as v1.4.0.

## What is removed

8 tools declared both here and by `netresearch/typo3-ci-workflows`, which this repo requires: `friendsofphp/php-cs-fixer`, `overtrue/phplint`, `phpstan/extension-installer`, `phpstan/phpstan`, `phpstan/phpstan-deprecation-rules`, `phpstan/phpstan-strict-rules`, `saschaegerer/phpstan-typo3`, `ssch/typo3-rector`.

Composer intersects the consumer constraint with the shared one and the narrower wins, so each duplicate is a place where a future narrowing holds an update back unnoticed. That is not hypothetical — in [t3x-contexts_wurfl](https://github.com/netresearch/t3x-contexts_wurfl/pull/44) a local `^2.0` kept `saschaegerer/phpstan-typo3` off 3.x while every other consumer had it, latest being 3.1.0.

Anything this repo declares for itself is untouched; only packages the shared package already provides are removed.

## What is added

`ergebnis/composer-normalize` under `config.allow-plugins` — the shared package ships it as of v1.4.0, and an unallowed Composer plugin is installed but never runs. The key sits in alphabetical position between `captainhook/hook-installer` and `infection/extension-installer`, which is where `composer normalize` puts it; the rest of the block is alphabetical already.

## What is bumped

`netresearch/typo3-ci-workflows` from `^1.3` to `^1.4`. The reason is the allow-plugins entry above, not the removals: `ergebnis/composer-normalize` enters the tree only through the shared package, which first requires it in v1.4.0, so `^1.3` declared less than this branch assumes. Raising the floor states that assumption instead of leaving it to chance.

The bump does not repair a broken resolution. In this repo `^1.3` already resolved to v1.4.0, because nothing else constrains the package downward and no `composer.lock` is committed. It is a declaration fix.

### Two claims from earlier revisions of this description, withdrawn

- **"Several of the tools removed above only exist in the shared package from v1.4.0, so a `^1.3` constraint permits a resolution (v1.3.x) that does not provide them."** False. All eight removed tools are already in `require` of `netresearch/typo3-ci-workflows` v1.3.2. The removals are safe under `^1.3`; only the plugin allowlist entry needs v1.4.0.
- **"With `^1.2` on `t3x-nr-passkeys-be` the resolver settles on v1.3.2, without `ergebnis/composer-normalize`."** False, and about a different repository in any case. A caret takes the highest matching release: `^1.2` means `>=1.2.0 <2.0.0`, which permits v1.4.0 and, with no committed lockfile, resolves to it. The v1.3.2 observation was a stale-cache artefact from the hour v1.4.0 was published. No constraint in this repo ever resolved below v1.4.0.

## Verification

Resolution measured before and after rather than argued from constraint algebra, both runs against an empty `COMPOSER_CACHE_DIR`:

```
$ composer update --dry-run --no-scripts --no-plugins --ignore-platform-reqs
before (main, ^1.3):        195 packages
after  (this branch, ^1.4): 195 packages
$ diff before.pkgs after.pkgs
(empty)
```

Package counts are `- Locking` lines: `grep -c '^  - Locking '` → 195, `grep -c '^  - Installing '` → 195, `grep -c '^  - '` → 390. An earlier revision of this description reported 390 for both sides; that figure counted every `^  - ` line, which matches each package twice, once as `- Locking` and once as `- Installing`. The stated numbers were exactly double. The before-equals-after conclusion is unaffected.

Both sides resolve the shared package identically — the `^1.3` side too, which is why this is a declaration fix and not a repair:

```
  - Locking netresearch/typo3-ci-workflows (v1.4.0)
  - Locking ergebnis/composer-normalize (2.52.0)
```
