### PR TITLE
Sync checks.yml template: pass languages: auto to CodeQL

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,6 +15,13 @@ permissions: {}
 # extension-specific test matrix lives in ci.yml (intentional-drift). Every
 # `uses:` job grants exactly the reusable's caller contract; no reliance on
 # default_workflow_permissions.
+#
+# ANY JOB ADDED BELOW MUST ALSO BE ADDED TO `gate.needs`. The gate is the only
+# context a ruleset requires, so a job missing from that list is a job whose
+# failure cannot block a merge — the coverage loss is silent, and nothing in CI
+# catches it. GitHub Actions does not support YAML anchors in workflow files,
+# so the list cannot be shared with the job definitions; it has to be kept in
+# step by hand.
 jobs:
   security:
     uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
@@ -44,12 +51,20 @@ jobs:
     permissions:
       contents: read
 
+  # `auto` rather than the `actions` default: a TYPO3 extension that ships
+  # JavaScript had none of it analysed, because the default scans workflows
+  # only and GitHub disables code-scanning default setup — which did cover
+  # javascript-typescript — as soon as an advanced configuration uploads its
+  # first SARIF. Merging this file is what triggers that handover, so the
+  # narrow default silently removed a control that had been in place.
   codeql:
     uses: netresearch/.github/.github/workflows/codeql.yml@main
     permissions:
       contents: read
       security-events: write
       actions: read
+    with:
+      languages: auto
 
   scorecard:
     if: github.event_name == 'schedule' || (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)


### PR DESCRIPTION
Syncs `.github/workflows/checks.yml` to the current [`templates/typo3-extension`](https://github.com/netresearch/.github/blob/main/templates/typo3-extension/.github/workflows/checks.yml) revision in netresearch/.github. The file is copied byte-identically; `git hash-object` on it and on the template return the same blob id.

## What changes

The `codeql` job called the reusable workflow with no `with:` block, so `languages` took its default value of `actions` — workflows only. The template now passes `languages: auto`, which detects `actions` always, `go` on a `go.mod` or any `.go` file, and `javascript-typescript` on a `package.json` or any JS/TS source. `auto` could not be used before, because it hardcoded Go.

A comment also records that any job added to this workflow must also be added to `gate.needs` — the gate is the only context a ruleset requires, so a job missing from that list is a job whose failure cannot block a merge.

## Expected effect on checks

None. This extension is PHP-only: it has no JavaScript, TypeScript or Go sources and no `package.json`, so `auto` resolves to `actions` here and CodeQL analyses exactly what it analysed before. This repository already carried the current `step-security/harden-runner` pin, so the sync removes template drift without changing any control.
