### PR TITLE
feat(agents): add AGENTS.md agent documentation and agent-harness verification

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,0 +1,99 @@
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-08-19 -->
+
+# AGENTS.md — workflows
+
+<!-- AGENTS-GENERATED:START overview -->
+## Overview
+Every workflow here is a thin caller of a central reusable in `netresearch/.github` or `netresearch/typo3-ci-workflows`. Repo-local files carry only triggers, per-job `permissions`, and `with:` inputs; the actual steps, checkout pins, and harden-runner live in the reusables.
+<!-- AGENTS-GENERATED:END overview -->
+
+<!-- AGENTS-GENERATED:START filemap -->
+## Key Files
+| File | Purpose |
+|------|---------|
+| `ci.yml` | Test matrix (PHP 8.2-8.5 × TYPO3 ^13.4/^14.3, pins `typo3/cms-core` + `typo3/cms-seo` per leg) via `typo3-ci-workflows/ci.yml` — intentional-drift, customize here |
+| `checks.yml` | Security/quality jobs + `All security checks` gate — byte-identical to the org template, drift-enforced, DO NOT edit locally |
+| `check-template-drift.yml` | Fails CI when drift-governed files diverge from `netresearch/.github/templates/typo3-extension/` |
+| `release.yml` | Tag-triggered GitHub release + TER publish; tags have NO `v` prefix (e.g. `14.0.0`) — intentional-drift |
+| `auto-merge-deps.yml` | Auto-merge for Dependabot/Renovate PRs (`pull_request_target`, no head checkout) |
+| `community.yml` | Stale-issue handling + first-contribution greeting |
+| `labeler.yml` | PR labeling from `.github/labeler.yml` |
+| `harness-verify.yml` | Agent-harness consistency check via `Build/Scripts/verify-harness.sh` |
+<!-- AGENTS-GENERATED:END filemap -->
+
+<!-- AGENTS-GENERATED:START setup -->
+## Workflow files
+- Drift governance: `.github/template.yaml` declares `template: typo3-extension`; only `ci.yml` and `release.yml` are listed as intentional-drift. Everything else must stay byte-identical to the template — change it upstream in `netresearch/.github`, not here. New files (not present in the template) are not byte-compared.
+- Required checks on `main` (rulesets): `All security checks`, `CodeQL`, `DCO`, `Opengrep OSS`, `betterleaks`, `ci / All CI checks`, `scorecard`, `zizmor`.
+<!-- AGENTS-GENERATED:END setup -->
+
+<!-- AGENTS-GENERATED:START structure -->
+## Directory structure
+```
+.github/
+  template.yaml     → drift-governance manifest (template + intentional-drift list)
+  dependabot.yml    → dependency update config
+  labeler.yml       → label rules used by labeler workflow
+  workflows/        → thin callers only (see Key Files above)
+```
+<!-- AGENTS-GENERATED:END structure -->
+
+<!-- AGENTS-GENERATED:START code-style -->
+## Workflow conventions
+- **Thin callers**: no repo-local `run:` step logic except the gate in `checks.yml`; extend the central reusable instead of inlining steps
+- **Explicit `permissions`**: top-level `permissions: {}` (or `contents: read`), each `uses:` job grants exactly the reusable's caller contract
+- **Pin direct action uses** to a full commit SHA with a version comment (see harden-runner in `checks.yml`)
+- **`pull_request_target` needs a zizmor ignore comment** (`# zizmor: ignore[dangerous-triggers]`) plus a prose justification why no PR head code runs
+- **Gate discipline**: any job added to `checks.yml` MUST also be added to `gate.needs` — a job missing there cannot block a merge and nothing catches the loss (but remember: `checks.yml` changes go through the org template)
+<!-- AGENTS-GENERATED:END code-style -->
+
+<!-- AGENTS-GENERATED:START patterns -->
+## Common patterns
+
+### Thin caller of a central reusable (the only pattern used here)
+```yaml
+permissions: {}
+
+jobs:
+  ci:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/ci.yml@main
+    permissions:
+      contents: read
+    with:
+      php-versions: '["8.2","8.3","8.4","8.5"]'
+      typo3-versions: '["^13.4","^14.3"]'
+      typo3-packages: '["typo3/cms-core","typo3/cms-seo"]'
+```
+Both core packages must be pinned per matrix leg — with only `typo3/cms-core` constrained, `typo3/cms-seo` could drift to the other major.
+<!-- AGENTS-GENERATED:END patterns -->
+
+<!-- AGENTS-GENERATED:START security -->
+## Security & safety
+- **Never** widen a `pull_request_target` workflow to check out or execute PR head code — the existing ones are safe precisely because they don't
+- **Pass secrets explicitly** (`secrets:` block, e.g. `CODECOV_TOKEN`, `TYPO3_TER_ACCESS_TOKEN`); never `secrets: inherit`
+- **Minimal permissions**: start from `permissions: {}` and add per job only what the reusable's contract requires
+- **zizmor and CodeQL scan these files** — both are required checks; a finding here blocks every PR
+<!-- AGENTS-GENERATED:END security -->
+
+<!-- AGENTS-GENERATED:START checklist -->
+## PR/commit checklist
+- [ ] Change belongs here — drift-governed files (`checks.yml`, `community.yml`, ...) are edited in `netresearch/.github/templates/typo3-extension/`, only `ci.yml`/`release.yml` in-repo
+- [ ] `permissions` blocks are minimal and per-job
+- [ ] Any direct `uses:` step pinned to a full SHA with version comment
+- [ ] `pull_request_target` additions carry the zizmor ignore comment + justification
+- [ ] Release tags follow the repo's no-`v`-prefix scheme (`14.0.0`) — `release.yml` matches both spellings for safety
+<!-- AGENTS-GENERATED:END checklist -->
+
+<!-- AGENTS-GENERATED:START examples -->
+## Patterns to Follow
+> **Prefer looking at real code in this repo over generic examples.**
+> `ci.yml` (matrix caller with inline rationale comments) and `checks.yml` (gate pattern with its full design rationale in comments) are the reference implementations.
+<!-- AGENTS-GENERATED:END examples -->
+
+<!-- AGENTS-GENERATED:START help -->
+## When stuck
+- Central reusables: https://github.com/netresearch/.github and https://github.com/netresearch/typo3-ci-workflows
+- Template source for drift-governed files: `netresearch/.github/templates/typo3-extension/`
+- GitHub Actions workflow syntax: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
+- The long comments inside `checks.yml` and `release.yml` document the non-obvious decisions (gate vs. required checks, merge-queue behavior, tag scheme)
+<!-- AGENTS-GENERATED:END help -->

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/.github/workflows/harness-verify.yml
+++ b/.github/workflows/harness-verify.yml
@@ -1,0 +1,23 @@
+name: Harness Verification
+
+# Verifies agent-harness consistency (AGENTS.md line budget, dead references,
+# documented commands vs composer.json/Makefile, docs/ structure) via
+# Build/Scripts/verify-harness.sh. Thin caller of the shared script-check
+# reusable, so the checkout pin and harden-runner are maintained centrally.
+# Exit 2 means warnings only and passes; exit 1 (errors) fails the check.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  harness-verify:
+    uses: netresearch/.github/.github/workflows/script-check.yml@main
+    permissions:
+      contents: read
+    with:
+      check-cmd: bash Build/Scripts/verify-harness.sh || [ $? -eq 2 ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,129 @@
+<!-- FOR AI AGENTS - Human readability is a side effect, not a goal -->
+<!-- Managed by agent: keep sections and order; edit content, not structure -->
+<!-- Last updated: 2026-08-19 | Last verified: 2026-08-19 -->
+
+# AGENTS.md
+
+**Precedence:** the **closest `AGENTS.md`** to the files you're changing wins. Root holds global defaults only.
+
+TYPO3 extension `nr_image_sitemap` (`netresearch/nr-image-sitemap`): an image-sitemap XmlSitemapDataProvider for `typo3/cms-seo`. Supports TYPO3 ^13.4 / ^14.3 on PHP ^8.2 (version: see `ext_emconf.php`). Component map: `docs/ARCHITECTURE.md`.
+
+## Commands
+> Source: `composer.json` scripts (mirrored by `Makefile` targets). Run `composer install` first — tooling comes from the `netresearch/typo3-ci-workflows` dev dependency; binaries land in `.build/bin/`, not `vendor/bin/`.
+
+<!-- AGENTS-GENERATED:START commands -->
+| Task | Command |
+|------|---------|
+| PHP lint | `composer ci:test:php:lint` |
+| Code style (dry-run) | `composer ci:test:php:cgl` (= `make cgl`) |
+| Code style (fix) | `composer ci:cgl` (= `make cgl-fix`) |
+| PHPStan | `composer ci:test:php:phpstan` (= `make phpstan`) |
+| Rector (dry-run) | `composer ci:test:php:rector` (= `make rector`) |
+| Unit tests | `composer ci:test:php:unit` |
+| Functional tests | `composer ci:test:php:functional` (needs a database; CI runs these in the reusable matrix) |
+| Everything | `composer ci:test` |
+<!-- AGENTS-GENERATED:END commands -->
+
+> If commands fail, verify against `composer.json`/`Makefile` and update this table in the same PR.
+
+## Response Style
+- Answer first, elaborate only if needed. No sycophantic openers ("Great question!", "Absolutely!").
+- For yes/no or status questions, lead with the answer.
+- Skip preamble. Match response length to task complexity.
+
+## Workflow
+1. **Before coding**: Read nearest `AGENTS.md` + check Golden Samples for the area you're touching
+2. **After each change**: Run the smallest relevant check (lint → phpstan → unit tests)
+3. **Before committing**: Run full test suite if changes affect >2 files or touch shared code
+4. **Before claiming done**: Run verification and **show output as evidence** — never say "try again", "should work now", "tested", "verified", or "all green" without pasted command output in the same turn
+
+## File Map
+<!-- AGENTS-GENERATED:START filemap -->
+```
+Classes/         → PHP source, PSR-4 Netresearch\NrImageSitemap\ (Domain/Model, Domain/Repository, Seo)
+Configuration/   → Services.yaml, TypoScript, Site Set (Sets/ImageSitemap), TCA override, Icons, Extbase persistence
+Resources/       → Fluid sitemap template (Private/Templates/Sitemap/Images.xml) + extension icon
+Tests/           → PHPUnit tests (Unit/, Functional/ + Functional/Fixtures)
+Build/           → tool configs (php-cs-fixer, phpstan, rector, phplint, phpunit XMLs) + Scripts/verify-harness.sh
+docs/            → agent-facing docs: ARCHITECTURE.md, exec-plans/
+```
+<!-- AGENTS-GENERATED:END filemap -->
+
+## Golden Samples (follow these patterns)
+<!-- AGENTS-GENERATED:START golden-samples -->
+| For | Reference | Key patterns |
+|-----|-----------|--------------|
+| Functional test | `Tests/Functional/Seo/ImagesXmlSitemapTest.php` | testing-framework setup, CSV fixtures from `Tests/Functional/Fixtures/Database/` |
+| Unit test | `Tests/Unit/Domain/Model/ImageFileReferenceTest.php` | plain UnitTestCase structure |
+| DB access | `Classes/Domain/Repository/ImageFileReferenceRepository.php` | QueryBuilder with named int/string array parameters |
+<!-- AGENTS-GENERATED:END golden-samples -->
+
+## Heuristics (quick decisions)
+<!-- AGENTS-GENERATED:START heuristics -->
+| When | Do |
+|------|-----|
+| Adding a class | PSR-4 under `Classes/`; `Configuration/Services.yaml` autowires `Netresearch\NrImageSitemap\` |
+| Changing sitemap content/selection | `ImageFileReferenceRepository` (query) or `ImagesXmlSitemapDataProvider` (assembly) — see `docs/ARCHITECTURE.md` |
+| Changing sitemap XML output | `Resources/Private/Templates/Sitemap/Images.xml` |
+| Changing TypoScript options | Update BOTH `Configuration/TypoScript/` and the Site Set in `Configuration/Sets/ImageSitemap/` |
+| Raising PHP/TYPO3 floors | Update `composer.json`, `ext_emconf.php` constraints AND the `ci.yml` matrix in the same PR |
+| Running tasks | `make help` lists targets; composer scripts are the source of truth |
+| Committing | Conventional Commits (feat:, fix:, docs:, ...), signed + sign-off (see CONTRIBUTING.md) |
+| Adding dependency | Ask first - we minimize deps |
+<!-- AGENTS-GENERATED:END heuristics -->
+
+## Repository Settings
+<!-- AGENTS-GENERATED:START repo-settings -->
+- **Default branch:** `main`
+- **Merge strategy:** merge
+- **Signed commits:** required
+- **Required checks (rulesets):** `All security checks`, `CodeQL`, `DCO`, `Opengrep OSS`, `betterleaks`, `ci / All CI checks`, `scorecard`, `zizmor`
+- **Active rulesets:** Copilot review for default branch, require-signed-commits, t3x-baseline, t3x-pull-request
+<!-- AGENTS-GENERATED:END repo-settings -->
+
+## Boundaries
+
+### Always Do
+- Run pre-commit checks before committing
+- Add tests for new code paths
+- Use conventional commit format: `type(scope): subject`
+- Use **atomic commits** (one logical change per commit); preserve signatures, keep bisection useful
+- **Show test output as evidence before claiming work is complete** — never say "try again", "should work now", "tested", "verified", or "all green" without pasted command output
+- Before any edit, verify `pwd` resolves inside the intended repo worktree — not `.bare/`, not `~/.claude/skills/…`, not `~/.claude/plugins/cache/…` (those are read-only caches that get clobbered on update)
+- For upstream dependency fixes: run **full** test suite, not just affected tests
+- Force-push only with `--force-with-lease`
+- Follow PSR-12 coding standards and PHP ^8.2 features
+
+### Ask First
+- Adding new dependencies
+- Modifying CI/CD configuration (`.github/workflows/AGENTS.md` explains which files are drift-enforced)
+- Changing public API signatures
+- Repo-wide refactoring or rewrites
+- Operations that touch >3 repos (produce a dry-run plan first)
+
+### Never Do
+- Commit secrets, credentials, or sensitive data
+- Modify `.build/`, vendor, or generated files
+- Push directly to `main` — open a PR
+- Merge a PR before all review threads are resolved
+- Squash commits during merge or rebase unless the user explicitly asked
+- Edit installed skill/plugin cache paths (`~/.claude/skills/`, `~/.claude/plugins/cache/`, `**/.bare/**`) — always the source worktree
+- Reply to review comments with bare "Addressed" or "Fixed" — cite the resolving commit SHA
+- Commit a `composer.lock` — this extension deliberately ships none
+- Edit `.github/workflows/checks.yml` locally — it is byte-identical to the org template and drift-enforced
+
+## Contributing (for AI agents)
+- **Comprehension**: Understand the problem before submitting code. Read the linked issue, understand *why* the change is needed, not just *what* to change.
+- **Context**: Every PR must explain the trade-offs considered and link to the issue it addresses. Disclose AI assistance if the project requires it.
+- **Continuity**: Respond to review feedback. Drive-by PRs without follow-up will be closed.
+
+## Scoped AGENTS.md (MUST read when working in these directories)
+<!-- AGENTS-GENERATED:START scope-index -->
+- `./.github/workflows/AGENTS.md` — GitHub Actions workflows and CI/CD automation
+<!-- AGENTS-GENERATED:END scope-index -->
+
+> **Agents**: When you read or edit files in a listed directory, you **must** load its AGENTS.md first. It contains directory-specific conventions that override this root file.
+
+## When instructions conflict
+The nearest `AGENTS.md` wins. Explicit user prompts override files.
+- For PHP-specific patterns, follow PSR standards

--- a/Build/Scripts/verify-harness.sh
+++ b/Build/Scripts/verify-harness.sh
@@ -1,0 +1,756 @@
+#!/usr/bin/env bash
+# verify-harness.sh — Portable harness consistency checker
+# Checks AGENTS.md and related files for agent harness maturity.
+# Dependencies: coreutils + git (jq optional, graceful fallback)
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Globals
+# ---------------------------------------------------------------------------
+ERRORS=0
+WARNINGS=0
+FORMAT=""
+MAX_LEVEL=3
+SINGLE_CHECK=""
+STATUS_ONLY=false
+PLATFORM="${PLATFORM:-}"
+
+# Collected output lines (for final rendering)
+declare -a OUTPUT_LINES=()
+declare -a GITHUB_LINES=()
+declare -a GITLAB_LINES=()
+
+# Per-level pass/total counters
+declare -A LEVEL_PASS=( [1]=0 [2]=0 [3]=0 )
+declare -A LEVEL_TOTAL=( [1]=0 [2]=0 [3]=0 )
+
+# Track the first failing level-1 suggestion for --status
+NEXT_STEP=""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+usage() {
+    cat <<'USAGE'
+Usage: verify-harness.sh [OPTIONS]
+
+Verify agent harness consistency in the current repository.
+Must be run from the repo root.
+
+Options:
+  --format=text     Plain text output (default for terminals)
+  --format=github   GitHub Actions annotations (auto-detected in CI)
+  --format=gitlab   GitLab CI section annotations (auto-detected in CI)
+  --platform=P      Target platform: github, gitlab or forgejo (auto-detected
+                    from CI environment or git remote URL if not specified)
+  --level=N         Only check up to level N (1, 2, or 3; default: all)
+  --check=NAME      Run single check category: refs, commands, drift, structure
+  --status          Show current maturity level summary only
+  --help            Show this help message
+
+Exit codes:
+  0  All checks pass
+  1  Errors found (Level 1/2 failures)
+  2  Only warnings (Level 3 suggestions)
+USAGE
+    exit 0
+}
+
+# Detect output format: github if running in CI, otherwise text
+detect_format() {
+    if [[ -n "$FORMAT" ]]; then
+        return
+    fi
+    if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+        FORMAT="github"
+    elif [[ "${GITLAB_CI:-}" == "true" ]]; then
+        FORMAT="gitlab"
+    else
+        FORMAT="text"
+    fi
+}
+
+# Detect hosting platform from CI env, git remote, or flag
+detect_platform() {
+    if [[ -n "$PLATFORM" ]]; then
+        if [[ "$PLATFORM" != "github" && "$PLATFORM" != "gitlab" && "$PLATFORM" != "forgejo" ]]; then
+            echo "Error: Unsupported PLATFORM '${PLATFORM}'. Expected 'github', 'gitlab' or 'forgejo'." >&2
+            exit 1
+        fi
+        return
+    fi
+    if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+        # Forgejo/Gitea Actions also export GITHUB_ACTIONS=true; tell them apart
+        # by the server URL — github.com (or a *.github.* Enterprise host) is real
+        # GitHub, anything else is a self-hosted Forgejo/Gitea instance.
+        if [[ -n "${GITHUB_SERVER_URL:-}" && "${GITHUB_SERVER_URL}" != *"github."* ]]; then
+            PLATFORM="forgejo"
+        else
+            PLATFORM="github"
+        fi
+        return
+    fi
+    if [[ "${GITLAB_CI:-}" == "true" ]]; then
+        PLATFORM="gitlab"
+        return
+    fi
+    local remote_url=""
+    remote_url=$(git remote get-url origin 2>/dev/null || true)
+    if [[ "$remote_url" == *"forgejo"* || "$remote_url" == *"gitea"* ]]; then
+        PLATFORM="forgejo"
+    elif [[ "$remote_url" == *"github"* ]]; then
+        PLATFORM="github"
+    elif [[ "$remote_url" == *"gitlab"* ]]; then
+        PLATFORM="gitlab"
+    elif [[ -f ".gitlab-ci.yml" ]]; then
+        # Infer GitLab from CI config presence (e.g. self-hosted GitLab)
+        PLATFORM="gitlab"
+    elif [[ -d ".forgejo" || -d ".gitea" ]]; then
+        # Infer Forgejo/Gitea from config presence (self-hosted)
+        PLATFORM="forgejo"
+    elif [[ -d ".github" ]]; then
+        PLATFORM="github"
+    else
+        PLATFORM="github"
+    fi
+}
+
+# Record a passing check
+pass() {
+    local level="$1"
+    local msg="$2"
+    (( LEVEL_PASS[$level]++ )) || true
+    (( LEVEL_TOTAL[$level]++ )) || true
+    OUTPUT_LINES+=("  PASS|${level}|${msg}")
+}
+
+# Record a failing check (error)
+fail() {
+    local level="$1"
+    local msg="$2"
+    local file="${3-AGENTS.md}"
+    (( ERRORS++ )) || true
+    (( LEVEL_TOTAL[$level]++ )) || true
+    OUTPUT_LINES+=("  FAIL|${level}|${msg}")
+    GITHUB_LINES+=("::error file=${file}::${msg} -- required for Level ${level} harness maturity")
+    GITLAB_LINES+=("ERROR: [Level ${level}] ${msg}${file:+ (${file})}")
+    # Capture first actionable suggestion for --status
+    if [[ -z "$NEXT_STEP" ]]; then
+        NEXT_STEP="$msg"
+    fi
+}
+
+# Record a warning
+warn() {
+    local level="$1"
+    local msg="$2"
+    local file="${3-AGENTS.md}"
+    (( WARNINGS++ )) || true
+    (( LEVEL_TOTAL[$level]++ )) || true
+    OUTPUT_LINES+=("  WARN|${level}|${msg}")
+    GITHUB_LINES+=("::warning file=${file}::${msg}")
+    GITLAB_LINES+=("WARNING: [Level ${level}] ${msg}${file:+ (${file})}")
+    if [[ -z "$NEXT_STEP" ]]; then
+        NEXT_STEP="$msg"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Level 1 checks — Basic
+# ---------------------------------------------------------------------------
+check_agents_md_exists() {
+    if [[ -f "AGENTS.md" ]]; then
+        pass 1 "AGENTS.md exists"
+    else
+        fail 1 "AGENTS.md missing at repo root"
+    fi
+}
+
+check_agents_md_length() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 1 "AGENTS.md length check skipped (file missing)"
+        return
+    fi
+    local lines
+    lines=$(wc -l < "AGENTS.md")
+    if (( lines < 150 )); then
+        pass 1 "AGENTS.md is index-format (${lines} lines)"
+    else
+        fail 1 "AGENTS.md is ${lines} lines (should be under 150)"
+    fi
+}
+
+check_agents_md_commands() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 1 "Commands section check skipped (AGENTS.md missing)"
+        return
+    fi
+    if grep -qi '^## *\(available \)\?commands' "AGENTS.md"; then
+        pass 1 "Commands section found"
+    else
+        fail 1 "AGENTS.md missing ## Commands section"
+    fi
+}
+
+check_docs_exists() {
+    if [[ -d "docs" ]]; then
+        pass 1 "docs/ directory exists"
+    else
+        fail 1 "docs/ directory missing" ""
+    fi
+}
+
+run_level1() {
+    check_agents_md_exists
+    check_agents_md_length
+    check_agents_md_commands
+    check_docs_exists
+}
+
+# ---------------------------------------------------------------------------
+# Level 2 checks — Verified
+# ---------------------------------------------------------------------------
+
+# Check that all local file references in AGENTS.md resolve
+check_refs() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 2 "Reference check skipped (AGENTS.md missing)"
+        return
+    fi
+    local has_broken=false
+    # Extract markdown links: [text](path) — skip http(s):// and #anchors
+    while IFS= read -r ref; do
+        # Strip anchor (#...) and query string (?...)
+        local clean
+        clean="${ref%%#*}"
+        clean="${clean%%\?*}"
+        # Skip empty after stripping
+        [[ -z "$clean" ]] && continue
+        # Skip URLs
+        [[ "$clean" =~ ^https?:// ]] && continue
+        # Check if file/dir exists
+        if [[ ! -e "$clean" ]]; then
+            warn 2 "Broken reference in AGENTS.md: ${ref} -> ${clean} not found"
+            has_broken=true
+        fi
+    done < <(grep -oP '\]\(\K[^)]+' "AGENTS.md" 2>/dev/null || true)
+
+    if [[ "$has_broken" == false ]]; then
+        pass 2 "All references resolve"
+    fi
+}
+
+# Check that documented commands have matching targets/scripts
+check_commands() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 2 "Command check skipped (AGENTS.md missing)"
+        return
+    fi
+
+    local found_any=false
+
+    # -- Makefile targets --
+    if [[ -f "Makefile" ]]; then
+        found_any=true
+        local has_make_issue=false
+        while IFS= read -r target; do
+            # Check if Makefile defines this target (pattern: "target:" at start of line)
+            if ! grep -qE "^${target}[[:space:]]*:" "Makefile"; then
+                warn 2 "make ${target}: no matching Makefile target (warning)"
+                has_make_issue=true
+            fi
+        done < <(grep -oP '`make\s+\K[a-zA-Z0-9_-]+' "AGENTS.md" 2>/dev/null || true)
+        if [[ "$has_make_issue" == false ]]; then
+            local make_count
+            make_count=$(grep -oP '`make\s+\K[a-zA-Z0-9_-]+' "AGENTS.md" 2>/dev/null | wc -l || true)
+            if [[ "$make_count" -gt 0 ]]; then
+                pass 2 "All make targets verified (${make_count} targets)"
+            fi
+        fi
+    fi
+
+    # -- composer.json scripts --
+    if [[ -f "composer.json" ]]; then
+        found_any=true
+        local has_composer_issue=false
+        # Built-in composer commands that are NOT user-defined scripts
+        local composer_builtins="install|update|require|remove|dump-autoload|dumpautoload|clear-cache|clearcache|config|create-project|exec|global|init|outdated|prohibits|why|why-not|search|self-update|selfupdate|show|status|validate|archive|browse|check-platform-reqs|diagnose|fund|licenses|run-script|suggests|upgrade"
+        while IFS= read -r script; do
+            # Skip built-in composer commands
+            if echo "$script" | grep -qE "^(${composer_builtins})$"; then
+                continue
+            fi
+            # Look for the script name in composer.json's scripts section
+            # Using grep since jq is optional
+            if ! grep -qE "\"${script}\"" "composer.json"; then
+                warn 2 "composer ${script}: no matching composer.json script (warning)"
+                has_composer_issue=true
+            fi
+        done < <(grep -oP '`composer\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null || true)
+        if [[ "$has_composer_issue" == false ]]; then
+            local composer_count
+            composer_count=$(grep -oP '`composer\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null | wc -l || true)
+            if [[ "$composer_count" -gt 0 ]]; then
+                pass 2 "All composer scripts verified (${composer_count} scripts)"
+            fi
+        fi
+    fi
+
+    # -- package.json scripts --
+    if [[ -f "package.json" ]]; then
+        found_any=true
+        local has_npm_issue=false
+        while IFS= read -r script; do
+            if ! grep -qE "\"${script}\"" "package.json"; then
+                warn 2 "npm run ${script}: no matching package.json script (warning)"
+                has_npm_issue=true
+            fi
+        done < <(grep -oP '`npm run\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null || true)
+        if [[ "$has_npm_issue" == false ]]; then
+            local npm_count
+            npm_count=$(grep -oP '`npm run\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null | wc -l || true)
+            if [[ "$npm_count" -gt 0 ]]; then
+                pass 2 "All npm scripts verified (${npm_count} scripts)"
+            fi
+        fi
+    fi
+
+    if [[ "$found_any" == false ]]; then
+        pass 2 "No build system files found to check commands against"
+    fi
+}
+
+check_architecture_doc() {
+    if [[ -f "docs/ARCHITECTURE.md" ]]; then
+        pass 2 "docs/ARCHITECTURE.md exists"
+    else
+        fail 2 "docs/ARCHITECTURE.md missing" ""
+    fi
+}
+
+check_ci_workflow() {
+    if [[ "$PLATFORM" == "gitlab" ]]; then
+        if [[ -f ".gitlab-ci.yml" ]]; then
+            # Search root file and all include:local files for harness job
+            local found_harness=false
+            if grep -qE "harness-verify|verify-harness" ".gitlab-ci.yml"; then
+                found_harness=true
+            else
+                # Check files referenced via include:local (supports globs).
+                # Portable parser using sed/awk — handles common GitLab CI forms:
+                #   include: { local: 'path' }
+                #   include:
+                #     - local: 'path'
+                #   include:
+                #     - local:
+                #         - path1
+                #         - path2
+                # Skips PCRE (-P) and lookaround for BSD/macOS grep portability.
+                while IFS= read -r inc_pattern; do
+                    [[ -z "$inc_pattern" ]] && continue
+                    # shellcheck disable=SC2086
+                    for inc_file in $inc_pattern; do
+                        if [[ -f "$inc_file" ]] && grep -qE "harness-verify|verify-harness" "$inc_file"; then
+                            found_harness=true
+                            break 2
+                        fi
+                    done
+                done < <(awk '
+                    /^[[:space:]]*-?[[:space:]]*local:[[:space:]]*\[/ {
+                        # inline list form: local: [a.yml, b.yml]
+                        s=$0; sub(/.*local:[[:space:]]*\[/,"",s); sub(/\].*/,"",s);
+                        n=split(s, a, /[[:space:]]*,[[:space:]]*/);
+                        for (i=1;i<=n;i++) print a[i]; next
+                    }
+                    /^[[:space:]]*-?[[:space:]]*local:[[:space:]]*[^[:space:]\[]/ {
+                        # scalar form: local: path or - local: path
+                        s=$0; sub(/.*local:[[:space:]]*/,"",s); print s; next
+                    }
+                ' ".gitlab-ci.yml" 2>/dev/null | tr -d "'\"" || true)
+            fi
+            if [[ "$found_harness" == true ]]; then
+                pass 2 "CI harness job found in GitLab CI config"
+            else
+                warn 2 "CI config exists (.gitlab-ci.yml) but no harness-verify job found"
+            fi
+        else
+            fail 2 "CI harness workflow missing -- create .gitlab-ci.yml with a harness-verify job" ""
+        fi
+    elif [[ "$PLATFORM" == "forgejo" ]]; then
+        if [[ -f ".forgejo/workflows/harness-verify.yml" || -f ".gitea/workflows/harness-verify.yml" ]]; then
+            pass 2 "CI harness workflow exists"
+        else
+            fail 2 "CI harness workflow missing -- create .forgejo/workflows/harness-verify.yml" ""
+        fi
+    else
+        if [[ -f ".github/workflows/harness-verify.yml" ]]; then
+            pass 2 "CI harness workflow exists"
+        else
+            fail 2 "CI harness workflow missing -- create .github/workflows/harness-verify.yml" ""
+        fi
+    fi
+}
+
+run_level2() {
+    check_refs
+    check_commands
+    check_architecture_doc
+    check_ci_workflow
+}
+
+# ---------------------------------------------------------------------------
+# Level 3 checks — Enforced
+# ---------------------------------------------------------------------------
+
+check_hooks_autosetup() {
+    local found=false
+    local via=""
+
+    # Check .envrc for hooksPath
+    if [[ -f ".envrc" ]] && grep -q "hooksPath" ".envrc"; then
+        found=true
+        via=".envrc"
+    fi
+
+    # Check for Husky
+    if [[ -d ".husky" ]]; then
+        found=true
+        via=".husky"
+    fi
+
+    # Check composer.json for post-install-cmd with hooks
+    if [[ -f "composer.json" ]] && grep -q "post-install-cmd" "composer.json"; then
+        if grep -q "hook" "composer.json"; then
+            found=true
+            via="composer.json post-install-cmd"
+        fi
+    fi
+
+    if [[ "$found" == true ]]; then
+        pass 3 "Git hooks auto-setup via ${via}"
+    else
+        warn 3 "No git hooks auto-setup detected (.envrc hooksPath, .husky/, or composer.json post-install-cmd)"
+    fi
+}
+
+check_pr_template() {
+    if [[ "$PLATFORM" == "forgejo" ]]; then
+        # Forgejo/Gitea honour PR templates under .forgejo/, .gitea/ or .github/
+        local f
+        for f in .forgejo/pull_request_template.md .gitea/pull_request_template.md \
+                 .forgejo/PULL_REQUEST_TEMPLATE.md .gitea/PULL_REQUEST_TEMPLATE.md \
+                 .github/pull_request_template.md; do
+            if [[ -f "$f" ]]; then
+                pass 3 "PR template exists ($f)"
+                return
+            fi
+        done
+        warn 3 "PR template missing (create .forgejo/pull_request_template.md)"
+        return
+    fi
+    if [[ "$PLATFORM" == "gitlab" ]]; then
+        if [[ -d ".gitlab/merge_request_templates" ]]; then
+            local tmpl_count
+            tmpl_count=$(find .gitlab/merge_request_templates -maxdepth 1 -type f -name '*.md' 2>/dev/null | wc -l)
+            if (( tmpl_count > 0 )); then
+                pass 3 "MR template exists (.gitlab/merge_request_templates/, ${tmpl_count} template(s))"
+                return
+            fi
+        fi
+        warn 3 "MR template missing (create .gitlab/merge_request_templates/Default.md)"
+    else
+        if [[ -f ".github/pull_request_template.md" ]]; then
+            pass 3 "PR template exists (repo-level)"
+            return
+        fi
+        if [[ -d ".github/PULL_REQUEST_TEMPLATE" ]]; then
+            pass 3 "PR template exists (directory form)"
+            return
+        fi
+        local org=""
+        org=$(git remote get-url origin 2>/dev/null | sed -n 's|.*github\.com[:/]\([^/]*\)/.*|\1|p')
+        if [[ -n "$org" ]]; then
+            local api_result=""
+            api_result=$(gh api "repos/${org}/.github/contents/pull_request_template.md" --jq '.name' 2>/dev/null || true)
+            if [[ "$api_result" == "pull_request_template.md" ]]; then
+                pass 3 "PR template exists (org-level via ${org}/.github)"
+                return
+            fi
+        fi
+        warn 3 "PR template missing (.github/pull_request_template.md or org-level)"
+    fi
+}
+
+check_drift() {
+    # Skip if git is not available
+    if ! command -v git &>/dev/null; then
+        pass 3 "Drift check skipped (git not available)"
+        return
+    fi
+
+    # Skip if not in a git repo
+    if ! git rev-parse --git-dir &>/dev/null 2>&1; then
+        pass 3 "Drift check skipped (not a git repository)"
+        return
+    fi
+
+    # Skip if no parent commit (initial commit)
+    if ! git rev-parse HEAD~1 &>/dev/null 2>&1; then
+        pass 3 "Drift check skipped (no parent commit)"
+        return
+    fi
+
+    # Check if build/CI files changed in last commit
+    local build_files_changed=false
+    local agents_changed=false
+
+    while IFS= read -r changed_file; do
+        case "$changed_file" in
+            Makefile|composer.json|package.json|.github/workflows/*|.gitlab-ci.yml|.forgejo/workflows/*|.gitea/workflows/*)
+                build_files_changed=true
+                ;;
+            AGENTS.md)
+                agents_changed=true
+                ;;
+        esac
+    done < <(git diff --name-only HEAD~1 HEAD 2>/dev/null || true)
+
+    if [[ "$build_files_changed" == true && "$agents_changed" == false ]]; then
+        warn 3 "Potential drift: build/CI files changed in last commit but AGENTS.md was not updated"
+    else
+        pass 3 "No drift detected"
+    fi
+}
+
+run_level3() {
+    check_hooks_autosetup
+    check_pr_template
+    check_drift
+}
+
+# ---------------------------------------------------------------------------
+# Output rendering
+# ---------------------------------------------------------------------------
+
+render_text() {
+    echo "Agent Harness Verification"
+    echo "=========================="
+    echo ""
+
+    local current_level=0
+    local level_names=( [1]="Basic" [2]="Verified" [3]="Enforced" )
+
+    for line in "${OUTPUT_LINES[@]}"; do
+        local kind level msg
+        kind="${line%%|*}"
+        local rest="${line#*|}"
+        level="${rest%%|*}"
+        msg="${rest#*|}"
+        kind="${kind#"${kind%%[![:space:]]*}"}" # trim leading whitespace
+
+        # Print level header when level changes
+        if (( level != current_level )); then
+            if (( current_level != 0 )); then
+                echo ""
+            fi
+            echo "Level ${level} -- ${level_names[$level]}"
+            current_level=$level
+        fi
+
+        case "$kind" in
+            PASS) echo "  ✓ ${msg}" ;;
+            FAIL) echo "  ✗ ${msg}" ;;
+            WARN) echo "  ! ${msg}" ;;
+        esac
+    done
+
+    echo ""
+
+    # Summary line
+    local maturity_level=0
+    for lvl in 1 2 3; do
+        if (( ${LEVEL_TOTAL[$lvl]} > 0 && ${LEVEL_PASS[$lvl]} == ${LEVEL_TOTAL[$lvl]} )); then
+            maturity_level=$lvl
+        else
+            break
+        fi
+    done
+
+    local status="COMPLETE"
+    if (( maturity_level == 0 )); then
+        if (( LEVEL_TOTAL[1] > 0 && LEVEL_PASS[1] > 0 )); then
+            status="PARTIAL"
+        else
+            status="NONE"
+        fi
+        maturity_level=1
+    elif (( maturity_level < 3 )); then
+        # Check if next level is partially done
+        local next_lvl=$(( maturity_level + 1 ))
+        if (( ${LEVEL_TOTAL[$next_lvl]} > 0 && ${LEVEL_PASS[$next_lvl]} < ${LEVEL_TOTAL[$next_lvl]} )); then
+            status="PARTIAL"
+        fi
+    fi
+
+    echo "Summary: Level ${maturity_level} ${status} | ${ERRORS} error(s), ${WARNINGS} warning(s)"
+}
+
+render_github() {
+    if (( ${#GITHUB_LINES[@]} > 0 )); then
+        for line in "${GITHUB_LINES[@]}"; do
+            echo "$line"
+        done
+    fi
+}
+
+render_gitlab() {
+    local ts
+    ts=$(date +%s)
+    echo -e "\e[0Ksection_start:${ts}:harness_verify[collapsed=false]\r\e[0KAgent Harness Verification"
+    if (( ${#GITLAB_LINES[@]} > 0 )); then
+        for line in "${GITLAB_LINES[@]}"; do
+            echo "$line"
+        done
+    fi
+    echo ""
+    echo "Summary: ${ERRORS} error(s), ${WARNINGS} warning(s)"
+    echo -e "\e[0Ksection_end:${ts}:harness_verify\r\e[0K"
+}
+
+render_status() {
+    # Determine highest fully-passing level
+    local maturity_level=0
+    local level_names=( [1]="Basic" [2]="Verified" [3]="Enforced" )
+
+    for lvl in 1 2 3; do
+        if (( ${LEVEL_TOTAL[$lvl]} > 0 && ${LEVEL_PASS[$lvl]} == ${LEVEL_TOTAL[$lvl]} )); then
+            maturity_level=$lvl
+        else
+            break
+        fi
+    done
+
+    local status
+    if (( maturity_level == 0 )); then
+        if (( LEVEL_TOTAL[1] > 0 && LEVEL_PASS[1] > 0 )); then
+            status="PARTIAL"
+        else
+            status="NONE"
+        fi
+        # Display as Level 1 when no level is fully complete
+        local display_level=1
+        echo "Harness Maturity: Level ${display_level} (${level_names[$display_level]}) -- ${status}"
+    else
+        echo "Harness Maturity: Level ${maturity_level} (${level_names[$maturity_level]}) -- COMPLETE"
+    fi
+
+    for lvl in 1 2 3; do
+        if (( ${LEVEL_TOTAL[$lvl]} > 0 )); then
+            echo "  Level ${lvl}: ${LEVEL_PASS[$lvl]}/${LEVEL_TOTAL[$lvl]} checks pass"
+        fi
+    done
+
+    if [[ -n "$NEXT_STEP" ]]; then
+        echo "Next step: ${NEXT_STEP}"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --format=*)
+                FORMAT="${1#--format=}"
+                ;;
+            --platform=*)
+                PLATFORM="${1#--platform=}"
+                if [[ ! "$PLATFORM" =~ ^(github|gitlab|forgejo)$ ]]; then
+                    echo "Error: --platform must be 'github', 'gitlab' or 'forgejo'" >&2
+                    exit 1
+                fi
+                ;;
+            --level=*)
+                MAX_LEVEL="${1#--level=}"
+                if [[ ! "$MAX_LEVEL" =~ ^[123]$ ]]; then
+                    echo "Error: --level must be 1, 2, or 3" >&2
+                    exit 1
+                fi
+                ;;
+            --check=*)
+                SINGLE_CHECK="${1#--check=}"
+                ;;
+            --status)
+                STATUS_ONLY=true
+                ;;
+            --help|-h)
+                usage
+                ;;
+            *)
+                echo "Unknown option: $1" >&2
+                echo "Run with --help for usage info" >&2
+                exit 1
+                ;;
+        esac
+        shift
+    done
+
+    detect_format
+    detect_platform
+
+    # Run single check category if requested
+    if [[ -n "$SINGLE_CHECK" ]]; then
+        case "$SINGLE_CHECK" in
+            refs)       check_refs ;;
+            commands)   check_commands ;;
+            drift)      check_drift ;;
+            structure)
+                check_agents_md_exists
+                check_docs_exists
+                check_architecture_doc
+                check_ci_workflow
+                check_pr_template
+                ;;
+            *)
+                echo "Unknown check: ${SINGLE_CHECK}" >&2
+                echo "Valid checks: refs, commands, drift, structure" >&2
+                exit 1
+                ;;
+        esac
+    else
+        # Run all checks up to MAX_LEVEL
+        if (( MAX_LEVEL >= 1 )); then
+            run_level1
+        fi
+        if (( MAX_LEVEL >= 2 )); then
+            run_level2
+        fi
+        if (( MAX_LEVEL >= 3 )); then
+            run_level3
+        fi
+    fi
+
+    # Render output
+    if [[ "$STATUS_ONLY" == true ]]; then
+        render_status
+    elif [[ "$FORMAT" == "github" ]]; then
+        render_github
+    elif [[ "$FORMAT" == "gitlab" ]]; then
+        render_gitlab
+    else
+        render_text
+    fi
+
+    # Exit code
+    if (( ERRORS > 0 )); then
+        exit 1
+    elif (( WARNINGS > 0 )); then
+        exit 2
+    else
+        exit 0
+    fi
+}
+
+main "$@"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/captainhook.json
+++ b/captainhook.json
@@ -1,0 +1,35 @@
+{
+    "pre-commit": {
+        "actions": [
+            {
+                "action": "composer ci:test:php:cgl",
+                "conditions": []
+            },
+            {
+                "action": "composer ci:test:php:phpstan",
+                "conditions": []
+            }
+        ]
+    },
+    "commit-msg": {
+        "actions": [
+            {
+                "action": "\\CaptainHook\\App\\Hook\\Message\\Action\\Rules",
+                "options": {
+                    "rules": [
+                        "\\CaptainHook\\App\\Hook\\Message\\Rule\\MsgNotEmpty",
+                        "\\CaptainHook\\App\\Hook\\Message\\Rule\\LimitSubjectLength"
+                    ]
+                }
+            }
+        ]
+    },
+    "pre-push": {
+        "actions": [
+            {
+                "action": "composer ci:test:php:unit",
+                "conditions": []
+            }
+        ]
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,9 @@
         }
     },
     "scripts": {
+        "post-install-cmd": [
+            "[ -x .build/bin/captainhook ] && .build/bin/captainhook install --force --skip-existing || true"
+        ],
         "ci:cgl": [
             "php-cs-fixer fix --config Build/.php-cs-fixer.dist.php --diff --verbose --cache-file .build/.php-cs-fixer.cache"
         ],

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,34 @@
+# Architecture
+
+Agent-facing component map for `nr_image_sitemap`. Verified against the source on 2026-08-19 — if code and this file disagree, the code wins; fix this file in the same PR.
+
+## System overview
+
+The extension adds one sitemap type to `typo3/cms-seo`: an XML image sitemap. It contributes a `XmlSitemapDataProvider` implementation, the TypoScript/Site Set wiring that registers it under `plugin.tx_seo`, and a Fluid template that renders the collected image references as sitemap XML. There is no backend module, no controller, and no own database table — it reads `sys_file_reference`/`sys_file`/`pages`.
+
+## Components
+
+| Component | File | Role |
+|-----------|------|------|
+| Data provider | `Classes/Seo/ImagesXmlSitemapDataProvider.php` | Extends `AbstractXmlSitemapDataProvider` (cms-seo). Reads sitemap config (`tables`, `excludedDoktypes`, `additionalWhere`, `rootPage`), resolves the page tree, fetches images via the repository, groups them per page URL. Constructor signature is fixed by the cms-seo `XmlSitemapDataProviderInterface` contract; dependencies come via `GeneralUtility::makeInstance`. |
+| Repository | `Classes/Domain/Repository/ImageFileReferenceRepository.php` | Extbase `Repository` combined with a direct DBAL `QueryBuilder` over `sys_file_reference` ⋈ `sys_file` ⋈ `pages` (filters: page list, file type, tablenames, workspace 0, current language, optional doktype exclusion and raw `additionalWhere`). Verifies the foreign record exists, then hydrates `ImageFileReference` models via an Extbase `in(uid, …)` query. |
+| Domain model | `Classes/Domain/Model/ImageFileReference.php` | Extends Extbase `FileReference`; mapped to `sys_file_reference` in `Configuration/Extbase/Persistence/Classes.php`. `getTitle()`/`getDescription()` fall back to the underlying file's properties. |
+| Rendering | `Resources/Private/Templates/Sitemap/Images.xml` | Fluid template producing the `<image:image>` sitemap XML. Registered as template `Sitemap/Images` for the provider. |
+| Wiring (classic) | `Configuration/TypoScript/setup.typoscript` + `constants.typoscript` | Registers sitemap type `xmlImagesSitemap` under `plugin.tx_seo`, adds view paths, and clones `seo_sitemap` to `seo_sitemap_images` with `typeNum = 1642072014`. Static template registered via `Configuration/TCA/Overrides/sys_template.php`. |
+| Wiring (site sets) | `Configuration/Sets/ImageSitemap/` | TYPO3 v13+ Site Set `netresearch/image-sitemap` (depends on `typo3/seo-sitemap`) carrying the same TypoScript. |
+| DI | `Configuration/Services.yaml` | Autowires/autoconfigures everything under `Netresearch\NrImageSitemap\`. |
+
+## Data flow
+
+Frontend request with `typeNum=1642072014` → cms-seo sitemap rendering instantiates `ImagesXmlSitemapDataProvider` with the TypoScript `config` → provider resolves the root page (config override or site root) and its subtree via `PageRepository::getPageIdsRecursive` → `ImageFileReferenceRepository::findAllImages()` returns hydrated `ImageFileReference` models → provider groups them by page URI (md5 hash key) into `$this->items` → Fluid template `Sitemap/Images` renders the XML.
+
+## Dependency rules
+
+There is no architecture test suite (`Tests/Architecture/` does not exist). Observable layering: `Seo` depends on `Domain/Repository`, which depends on `Domain/Model`; nothing depends on `Seo`. Keep it that way — new query logic belongs in the repository, not the provider.
+
+## Key decisions
+
+- Constructor of the data provider cannot be changed (cms-seo interface contract); PHPStan suppressions for it live in `Build/phpstan.neon`.
+- `FileType::IMAGE->value` (the int), not the enum instance, is passed to the repository — DBAL cannot bind enum instances in `PARAM_INT_ARRAY`.
+- `additionalWhere` is a raw SQL fragment by design; callers are responsible for quoting (documented at `ImageFileReferenceRepository::findAllImages()`).
+- Release tags carry no `v` prefix (`14.0.0`) — rationale documented in `.github/workflows/release.yml`.

--- a/docs/exec-plans/README.md
+++ b/docs/exec-plans/README.md
@@ -1,0 +1,8 @@
+# Execution plans
+
+Working directory for multi-step agent task plans in this repo.
+
+- `active/` — plans currently being executed (create on demand)
+- `completed/` — finished plans kept for reference (create on demand)
+
+Keep plans short: goal, ordered steps with verification commands, and a completion checklist. Delete or move a plan when the work lands; a stale plan is worse than none.


### PR DESCRIPTION
Closes #48.

Adds curated agent documentation and agent-harness Level 2/3 infrastructure, mirroring netresearch/t3x-rte_ckeditor_image#888/#890. Root `AGENTS.md` carries only verified facts: the command table matches `composer.json` scripts and `Makefile` targets (binaries live in `.build/bin`, not `vendor/bin`), the file map matches the actual tree, and the repository-settings block was read back from the live rulesets via the GitHub API. The scoped `.github/workflows/AGENTS.md` replaces the generator's generic boilerplate with the repo's real model: every workflow is a thin caller of a central reusable, `checks.yml` is byte-governed by the typo3-extension template (only `ci.yml`/`release.yml` are intentional-drift), and release tags carry no `v` prefix. `docs/ARCHITECTURE.md` maps the three components (data provider, repository, domain model) and their wiring; every file path and claim was verified against the source. `CLAUDE.md` files are symlinks; there is no `Documentation/` directory in this repo, so the docs-renderer symlink exception does not apply.

Harness enforcement: `Build/Scripts/verify-harness.sh` (copy of the agent-harness skill script) runs in CI via `harness-verify.yml`, a thin caller of the shared script-check reusable (exit 2 = warnings-only passes). Git-hooks auto-setup uses `captainhook.json` (sibling convention, e.g. t3x-nr-image-optimize) plus a guarded composer `post-install-cmd` — captainhook already ships via the `netresearch/typo3-ci-workflows` dev dependency and the hook-installer plugin was already allow-listed; the guard makes the script a no-op when the binary is absent (e.g. `--no-dev` installs). The commit-msg rules deliberately omit CapitalizeSubject, which would reject Conventional Commit subjects.

## Test plan
- `validate-structure.sh`: 1 error / 0 warnings (no root AGENTS.md) → all checks pass, 0/0
- `score-agents.sh`: 0 files, average 0/100 → 2 files, average 95/100 (root 90, scoped 100)
- `verify-harness.sh`: Level 1 NONE, 8 errors / 2 warnings → Level 3 COMPLETE, 0 errors / 0 warnings
- `verify-content.sh`: all checks pass
- Root AGENTS.md is 129 lines (cap: under 150); fences balanced in every edited file; every referenced repo path checked for existence

- `composer validate`: valid
